### PR TITLE
remove comments

### DIFF
--- a/include/execute.h
+++ b/include/execute.h
@@ -1,6 +1,9 @@
 #ifndef EXECUTE_H
 #define EXECUTE_H
 
+#define CHILD_PROCESS_EXITED 0
+#define EXEC_RETURNED_FAILURE -1
+
 int trigger_launch(char **args);
 int trigger_execute(char **args);
 

--- a/include/input.h
+++ b/include/input.h
@@ -2,11 +2,12 @@
 #define INPUT_H
 
 #define TRIGGER_TOK_BUFFER_SIZE 64
+#define TRIGGER_AUTOMATIC_BUFFER_SIZE 0
+#define GETLINE_REACHED_END_OF_FILE_OR_ERROR -1
 #define TRIGGER_TOK_DELIM " \t\r\n\a"
 
-// Input reading and parsing functions
 char *trigger_read_line(void);
 char **trigger_split_line(char *line);
 
-#endif // INPUT_H
+#endif
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -7,10 +7,6 @@
 
 char *builtin_str[] = {"cd", "help", "exit"};
 
-/*
- * builtin_func is an array of pointers to functions that take a char** as an argument and return an int.
- * This is the devil.
- */
 int (*builtin_func[])(char **) = {&trigger_cd, &trigger_help, &trigger_exit};
 
 int trigger_num_builtins(void) {
@@ -21,7 +17,7 @@ int trigger_cd(char **args) {
     if (args[1] == NULL) {
         fprintf(stderr, "trigger: expected argument to \"cd\"\n");
     } else {
-        if (chdir(args[1]) != 0) {
+        if (chdir(args[1]) != EXIT_SUCCESS) {
             perror("trigger");
         }
     }
@@ -45,4 +41,3 @@ int trigger_help(char **args) {
 int trigger_exit(char **args) {
     return EXIT_SUCCESS;
 }
-

--- a/src/execute.c
+++ b/src/execute.c
@@ -13,23 +13,16 @@ int trigger_launch(char **args) {
 
     const pid_t pid = fork();
 
-    if (pid == 0) {
-        // It is a child process
-        if (execvp(args[0], args) == -1) {
-            // A process cannot ever return from execvp if it is successful.
+    if (pid == CHILD_PROCESS_EXITED) {
+        if (execvp(args[0], args) == EXEC_RETURNED_FAILURE) {
             perror("trigger");
         }
         exit(EXIT_FAILURE);
     } else if (pid < 0) {
-        // Error forking
         perror("trigger");
     } else {
-        // It is a parent process
         do {
             waitpid(pid, &status, WUNTRACED);
-
-            // the macros WIF EXITED and WIF SIGNALED are used to check if the child process has exited or
-            // was terminated by a signal.
         } while (!WIFEXITED(status) && !WIFSIGNALED(status));
     }
 

--- a/src/input.c
+++ b/src/input.c
@@ -5,18 +5,9 @@
 
 char *trigger_read_line(void) {
     char *line = NULL;
-    /*
-     * Why buffer_size is equal to 0? Because getline will allocate a buffer for us if the line pointer
-     * is NULL and the buffer size is 0.
-     *
-     * If the buffer size is not 0, getline will try to read into the buffer and if the buffer is not large enough,
-     * it will return an error.
-     *
-     * Thank God humans invented getline.
-     */
-    size_t buffer_size = 0;
+    size_t buffer_size = TRIGGER_AUTOMATIC_BUFFER_SIZE;
 
-    if (getline(&line, &buffer_size, stdin) == -1) {
+    if (getline(&line, &buffer_size, stdin) == GETLINE_REACHED_END_OF_FILE_OR_ERROR) {
         if (feof(stdin)) {
             exit(EXIT_SUCCESS);
         }


### PR DESCRIPTION
On why did I removed the comments:

Cuz 100% of 'em was unnecessary. There was one like

```c
if (pid == 0) {
// its a child
} else if (pid < 0) {
throw error} else {
// its parent}
```

like I know if the first condition is for the child, the second one is an error, so the last one must be a parent.
Or I explained that getline() will get me the buffer size automatically by putting the buffer size param to 0.

I could do better by defining macros like 
```c
    size_t buffer_size = TRIGGER_AUTOMATIC_BUFFER_SIZE;

    if (getline(&line, &buffer_size, stdin) == GETLINE_REACHED_END_OF_FILE_OR_ERROR) {
        if (feof(stdin)) {
            exit(EXIT_SUCCESS);
        }

        perror("readline");
        exit(EXIT_FAILURE);
    }
```

instead of 

```
   // why zero???
    size_t buffer_size = 0;

    if (getline(&line, &buffer_size, stdin) == -1) {
        if (feof(stdin)) {
            exit(EXIT_SUCCESS);
        }

        perror("readline");
        exit(EXIT_FAILURE);
    }
```

better than write a bible in my code. I can understand clearly what is happening here